### PR TITLE
Fix netlist warnings

### DIFF
--- a/xschem/sky130_td_ip__opamp_hp.sch
+++ b/xschem/sky130_td_ip__opamp_hp.sch
@@ -3066,8 +3066,6 @@ sa=0 sb=0 sd=0
 model=pfet_g5v0d10v5
 spiceprefix=X
 }
-C {devices/lab_wire.sym} 380 -560 0 0 {name=p7 sig_type=std_logic lab=avdd}
-C {devices/lab_wire.sym} 400 440 2 1 {name=p8 sig_type=std_logic lab=avss}
 C {devices/lab_wire.sym} -90 -110 2 0 {name=p9 sig_type=std_logic lab=avss}
 C {devices/lab_wire.sym} 90 -110 2 1 {name=p10 sig_type=std_logic lab=avss}
 C {devices/lab_wire.sym} -280 -10 2 0 {name=p11 sig_type=std_logic lab=avdd}

--- a/xschem/sky130_td_ip__opamp_hp_narrow.sch
+++ b/xschem/sky130_td_ip__opamp_hp_narrow.sch
@@ -3109,8 +3109,6 @@ sa=0 sb=0 sd=0
 model=pfet_g5v0d10v5
 spiceprefix=X
 }
-C {devices/lab_wire.sym} 380 -560 0 0 {name=p7 sig_type=std_logic lab=avdd}
-C {devices/lab_wire.sym} 400 440 2 1 {name=p8 sig_type=std_logic lab=avss}
 C {devices/lab_wire.sym} -90 -110 2 0 {name=p9 sig_type=std_logic lab=avss}
 C {devices/lab_wire.sym} 90 -110 2 1 {name=p10 sig_type=std_logic lab=avss}
 C {devices/lab_wire.sym} -280 -10 2 0 {name=p11 sig_type=std_logic lab=avdd}


### PR DESCRIPTION
Having a `ipin` and `lab_wire` on same net caused output short warning. This commit removes the offending `lab_wire`s.
Changing `ipin` to `iopin` would also resolve the issue.

Here's the warning before the fix
```
Warning: shorted output node: avdd
Warning: shorted output node: avss
```
<img width="739" alt="opamp" src="https://github.com/user-attachments/assets/a7f9ec3a-c11d-4702-b169-2c73ad264282">

